### PR TITLE
InputTextArea: bind input events to props.data

### DIFF
--- a/components/InputText.mjs
+++ b/components/InputText.mjs
@@ -123,7 +123,16 @@ export class InputTextArea extends Component {
         this.input = document.createElement("textarea");
         this.input.setAttribute('rows','6');
         this.input.style.padding = 'var(--spacerhalf)';
+        this.input.value = this.props.data[this.props.name] || "";
         this.element.append(this.input);
+        this.element.addEventListener('input', async e => {
+            this.props.data[this.props.name] = this.value;
+            await this.announceUpdate(this.props.name);
+            if (this.value !== this.originalValue) this.lock.add('exit');
+            else this.lock.clear('exit');
+        });
+        this.lock.clear();
+        this.originalValue = this.value;
     }
     async handleUpdate(attributeName) {
         await super.handleUpdate(attributeName);


### PR DESCRIPTION
## Summary
- `InputTextArea` never wrote its value back to `props.data` on input and never seeded the field from `props.data` on render — so consumers binding `data={...}` would read a stale value at save time.
- This change mirrors `InputText`'s render flow line-for-line (minus the datalist handling).

After this:
- Initializes the textarea from `props.data[name]`.
- Propagates input changes back to `props.data` and fires `announceUpdate`.
- Tracks `originalValue` to drive the exit-lock semantics.

## Test plan
- [ ] Render `<InputTextArea name="x" data={obj}>`, type, confirm `obj.x` updates on every keystroke.
- [ ] Pre-seed `obj.x = "hello"`, render, confirm the field shows "hello".
- [ ] Confirm `lock.add('exit')` fires when value diverges from initial, `lock.clear('exit')` when it matches.
- [ ] Spot-check existing pro-console flows that already use `InputTextArea` (e.g. `AdHeadlines` NewEntry textarea) still behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)